### PR TITLE
Feature/ENG-97: Free agents filter

### DIFF
--- a/client/app/(protected)/(tabs)/(home)/freeAgents.tsx
+++ b/client/app/(protected)/(tabs)/(home)/freeAgents.tsx
@@ -1,8 +1,9 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { Sliders } from "phosphor-react-native";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { View, Text, KeyboardAvoidingView, Pressable } from "react-native";
 import { FetchPlayersParams } from "../../(draft)/(teamBuilder)/players";
+import FiltersDrawer from "@/components/FiltersDrawer";
 import IconButton from "@/components/IconButton";
 import PlayerData from "@/components/PlayerData";
 import Screen from "@/components/Screen";
@@ -10,8 +11,10 @@ import SearchBar from "@/components/SearchBar";
 import Spinner from "@/components/Spinner";
 import Table from "@/components/Table/Table";
 import { NbaPlayersController } from "@/controllers/nbaPlayersController";
+import { NbaTeamsController } from "@/controllers/nbaTeamsController";
 import { useAppSelector } from "@/state/hooks";
-import { defaultPlayerFilters } from "@/types/player";
+import { NbaTeam } from "@/types/nbaTeams";
+import { defaultPlayerFilters, PlayerFilters } from "@/types/player";
 
 const PAGE_SIZE = 25;
 
@@ -20,6 +23,13 @@ const FreeAgents = () => {
   const team = useAppSelector((state) => state.team);
   const teamComposition =
     team.lineup.filter((slot) => slot.player).length + team.bench.length;
+  const [nbaTeams, setNBATeams] = useState<NbaTeam[]>([]);
+  const [showFiltersDrawer, setShowFiltersDrawer] = useState(false);
+  const [filters, setFilters] = useState<PlayerFilters>({
+    selectedTeams: [],
+    selectedPositions: [],
+    salaryRange: { min: 1000000, max: 150000000 },
+  });
 
   const excludedPlayerIds = useMemo(() => {
     const ids: string[] = [];
@@ -61,6 +71,20 @@ const FreeAgents = () => {
     initialPageParam: undefined,
   });
 
+  // TODO: Cache or store these assets so we can reduce fetches
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const teamsData = await NbaTeamsController.getAllTeams();
+        setNBATeams(teamsData);
+      } catch (error) {
+        console.error("Error fetching teams:", error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
   const tableData = useMemo(() => {
     const players = data?.pages.flatMap((page) => page.players) || [];
 
@@ -95,7 +119,7 @@ const FreeAgents = () => {
             <IconButton
               className="size-12 items-center justify-center rounded-lg border border-gray-800 bg-gray-900"
               icon={<Sliders color="white" />}
-              onPress={() => {}}
+              onPress={() => setShowFiltersDrawer(true)}
             />
           </View>
         </View>
@@ -150,6 +174,13 @@ const FreeAgents = () => {
           />
         )}
       </KeyboardAvoidingView>
+      <FiltersDrawer
+        filters={filters}
+        setFilters={setFilters}
+        setShowFiltersDrawer={() => setShowFiltersDrawer(false)}
+        showFiltersDrawer={showFiltersDrawer}
+        teams={nbaTeams}
+      />
     </Screen>
   );
 };

--- a/client/components/FiltersDrawer.tsx
+++ b/client/components/FiltersDrawer.tsx
@@ -153,7 +153,7 @@ const FiltersDrawer = ({
       }
       isOpen={showFiltersDrawer}
       onClose={setShowFiltersDrawer}
-      snapPoints={["80%"]}
+      snapPoints={["66%"]}
     >
       <Accordion selectedCount={localFilters.selectedTeams.length} title="Team">
         <ScrollView contentContainerClassName="flex-row flex-wrap justify-center gap-x-8 pb-36">


### PR DESCRIPTION
<!-- For titles, please adhere to the following title template if possible:
[Feature/Fix/Refactor]/[Identifier]: Short descriptive title
Ex. Bugfix/ENG-123: Fix app crash -->

## Related Issues

<!-- A link to any related issues or bugs that the pull request addresses, \
connecting the code's context with the issues it solves. Please see
https://linear.app/docs/github#link-to-a-linear-issue for keywords to link an issue.
Ex. Closes ENG-123, References ENG-456 -->

Closes ENG-97.

## Summary

<!-- Provide a concise summary as to why are the changes needed.
Include any relevant links, such as tickets, discussions, or design documents. -->

This PR implements filtering functionality into the free agents page. This also adjusts the `FiltersDrawer`'s snap point to `66%` from `80%` to recognize that it is a bottom sheet on all pages its being used in.

## Changes Made

<!-- Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem and any notable
implementation details. -->

- Integrated `FiltersDrawer` in `freeAgents.tsx`
- Fetches for NBATeams from firestore (maybe look into storing the data locally)
- Default snap point changed from 80% to 66% in `FiltersDrawer`

<!-- Optional Sections -->

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can help reviewers understand
them more easily. -->

No additional screenshots

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull request, helping reviewers
validate the code. -->

No additional testing instructions

## Special Notes for Your Reviewer(s)

<!-- If there are any specific instructions or considerations you want to highlight for the
reviewer, include them in this section. -->

No additional notes
