### PR TITLE
Feature/ENG-103: Set up win/loss record denormalization to teams subcollection

### DIFF
--- a/server/functions/src/index.ts
+++ b/server/functions/src/index.ts
@@ -974,6 +974,61 @@ export const weeklyMatchupReset = functions.pubsub
           });
 
           console.log(`Matchup ${matchupId} completed. Winner: ${winnerId}`);
+
+          const teams = [
+            {
+              userId: matchupData.home.homeUserId,
+              teamId: matchupData.home.homeTeamId,
+            },
+            {
+              userId: matchupData.away.awayUserId,
+              teamId: matchupData.away.awayTeamId,
+            },
+          ];
+
+          for (const team of teams) {
+            const teamRef = db
+              .collection("users")
+              .doc(team.userId)
+              .collection("teams")
+              .doc(team.teamId);
+
+            const teamDoc = await teamRef.get();
+            const isWin = winnerId === team.teamId;
+            const isDraw = winnerId === "";
+            const isLoss = !isWin && !isDraw;
+
+            if (teamDoc.exists) {
+              const teamData = teamDoc.data();
+              const current = teamData?.record || {
+                wins: 0,
+                losses: 0,
+                draws: 0,
+              };
+              await teamRef.update({
+                record: {
+                  wins: isWin ? current.wins + 1 : current.wins,
+                  losses: isLoss ? current.losses + 1 : current.losses,
+                  draws: isDraw ? current.draws + 1 : current.draws,
+                },
+              });
+            } else {
+              await teamRef.set(
+                {
+                  record: {
+                    wins: isWin ? 1 : 0,
+                    losses: isLoss ? 1 : 0,
+                    draws: isDraw ? 1 : 0,
+                  },
+                },
+                // This merge updates new data to an existing document
+                // without overwriting anything other fields
+                { merge: true },
+              );
+            }
+
+            console.log(`Updated record for team ${team.teamId}`);
+          }
         },
       );
 


### PR DESCRIPTION
<!-- For titles, please adhere to the following title template if possible:
[Feature/Fix/Refactor]/[Identifier]: Short descriptive title
Ex. Bugfix/ENG-123: Fix app crash -->

## Related Issues

<!-- A link to any related issues or bugs that the pull request addresses, \
connecting the code's context with the issues it solves. Please see
https://linear.app/docs/github#link-to-a-linear-issue for keywords to link an issue.
Ex. Closes ENG-123, References ENG-456 -->

Closes ENG-103.

## Summary

<!-- Provide a concise summary as to why are the changes needed.
Include any relevant links, such as tickets, discussions, or design documents. -->

This PR implements win/loss/draw record tracking for teams in the weekly matchup reset cloud function.

## Changes Made

<!-- Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem and any notable
implementation details. -->

- Create record object inside teams subcollection
- Modified `weeklyMatchupReset` cloud function to update both team records after a matchup has been completed.
- Record object tracks wins, losses and draws for a respective team.

<!-- Optional Sections -->

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can help reviewers understand
them more easily. -->

No additional screenshots

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull request, helping reviewers
validate the code. -->

No additional testing instructions

## Special Notes for Your Reviewer(s)

<!-- If there are any specific instructions or considerations you want to highlight for the
reviewer, include them in this section. -->

No additional notes
