### PR TITLE
Bugfix/ENG-118: Fix free agents crash when switching to league team

### DIFF
--- a/client/controllers/userController.ts
+++ b/client/controllers/userController.ts
@@ -138,10 +138,10 @@ export class UserController {
         id: team.id,
         logoUrl: team.data()?.logoUrl,
         name: team.data()?.name,
-        lineup: team.data()?.lineup,
-        bench: team.data()?.bench,
-        balance: team.data()?.balance,
-        record: team.data()?.record,
+        lineup: team.data()?.lineup ?? defaultTeam.lineup,
+        bench: team.data()?.bench ?? defaultTeam.bench,
+        balance: team.data()?.balance ?? TEAM_BALANCE,
+        record: team.data()?.record ?? defaultTeam.record,
         isLeagueTeam: team.data()?.isLeagueTeam ?? false,
       }));
     } catch (error) {


### PR DESCRIPTION
<!-- For titles, please adhere to the following title template if possible:
[Feature/Fix/Refactor]/[Identifier]: Short descriptive title
Ex. Bugfix/ENG-123: Fix app crash -->

## Related Issues

<!-- A link to any related issues or bugs that the pull request addresses, \
connecting the code's context with the issues it solves. Please see
https://linear.app/docs/github#link-to-a-linear-issue for keywords to link an issue.
Ex. Closes ENG-123, References ENG-456 -->

Closes ENG-118

## Summary

<!-- Provide a concise summary as to why are the changes needed.
Include any relevant links, such as tickets, discussions, or design documents. -->

When switching from a ranked team to a league team via the league switcher, the free agents page would crash with `TypeError: Cannot read property 'filter' of undefined`. League teams may not have a `lineup` stored in Firestore (e.g. newly created teams), so `getUserTeams` was returning `lineup: undefined` for those teams.

## Changes Made

<!-- Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem and any notable
implementation details. -->

Fixed `getUserTeams` in `userController.ts` to apply the same fallbacks that `getUserTeam` already had — defaulting `lineup`, `bench`, `balance`, and `record` to their `defaultTeam` values when absent from Firestore. Previously, `getUserTeams` returned raw `undefined` for these fields, while `getUserTeam` correctly fell back to `defaultTeam`.

<!-- Optional Sections -->

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can help reviewers understand
them more easily. -->

No additional screenshots

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull request, helping reviewers
validate the code. -->

1. Create or join a league so you have at least one league team
2. Navigate to the Free Agents tab while on a ranked team (empty lineup state)
3. Open the league switcher and switch to a league team
4. Verify the Free Agents tab loads without crashing

## Special Notes for Your Reviewer(s)

<!-- If there are any specific instructions or considerations you want to highlight for the
reviewer, include them in this section. -->

No additional notes
