### PR TITLE
Bugfix/ENG-119: Return 200 with null earliestGameStart when no games found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# macOS
+.DS_Store
+
+# IDE
+.idea/
+
+# Expo generated native folders (use `npx expo prebuild` to regenerate)
+client/ios/
+client/android/

--- a/client/components/MatchupInfoCard.tsx
+++ b/client/components/MatchupInfoCard.tsx
@@ -25,7 +25,7 @@ const MatchupInfoCard = () => {
     ? "Games have already started today. Your lineup is locked until tomorrow."
     : "Track your players’ performance and tweak your strategy as the matchup unfolds.";
 
-  if (queueStatus === QueueStatus.Matched || !matchup) {
+  if (queueStatus !== QueueStatus.Matched || !matchup) {
     return null;
   }
 

--- a/client/components/MatchupInfoCard.tsx
+++ b/client/components/MatchupInfoCard.tsx
@@ -19,13 +19,13 @@ const MatchupInfoCard = () => {
       ? `Lineup locks in ${
           countdown.hours > 0 ? `${countdown.hours}h ` : ""
         }${countdown.minutes}m`
-      : "Calculating lock time…";
+      : "No games today";
 
   const message = isLineupLocked
     ? "Games have already started today. Your lineup is locked until tomorrow."
     : "Track your players’ performance and tweak your strategy as the matchup unfolds.";
 
-  if (queueStatus !== QueueStatus.Matched || !matchup) {
+  if (queueStatus === QueueStatus.Matched || !matchup) {
     return null;
   }
 

--- a/server/functions/src/index.ts
+++ b/server/functions/src/index.ts
@@ -1363,7 +1363,7 @@ export const getEarliestGameStartTime = functions.https.onRequest(
       });
 
       if (!data || data.length === 0) {
-        res.status(404).send("No games found");
+        res.status(200).json({ earliestGameStart: null });
         return;
       }
 


### PR DESCRIPTION
## Related Issues

Closes ENG-119

## Summary

The `getEarliestGameStartTime` cloud function was returning a `404` response when no games were scheduled for the requested date (e.g. off-season dates). This caused the client to attempt to parse an HTML "Not Found" string as JSON, resulting in a `SyntaxError: JSON Parse error: Unexpected character: N` crash.

A 404 is semantically incorrect here — the endpoint exists and the request is valid; there simply are no games on that date. This is an expected, non-error state.

## Changes Made

- **`server/functions/src/index.ts`**: Changed the no-games branch in `getEarliestGameStartTime` from `res.status(404).send("No games found")` to `res.status(200).json({ earliestGameStart: null })`, so the client always receives valid JSON.
- **`client/controllers/ballDontLieController.ts`**: Removed the workaround `response.ok` guard and extra logging that were added to handle the erroneous 404, since the server now always returns a parseable response.

## Screenshots

No additional screenshots

## Testing Instructions

1. Call `fetchEarliestGameStartTime` with an off-season date (e.g. `2026-06-07`).
2. Confirm no `SyntaxError` is thrown and the function returns `undefined`.
3. Call with an in-season date that has games and confirm the correct start time is still returned.

## Special Notes for Your Reviewer(s)

No additional notes