### PR TITLE
ENG-122: Disable queue button and fix lineup lock outside active matchup

### DIFF
--- a/client/app/(protected)/(tabs)/index.tsx
+++ b/client/app/(protected)/(tabs)/index.tsx
@@ -32,6 +32,9 @@ import { QueueStatus } from "@/types/user";
 import { cn, isNotNil } from "@/utils/jsUtils";
 import { isTeamReadyForQueue } from "@/utils/teamUtils";
 
+// Re-enable once queue bugs are fixed
+const QUEUE_ENABLED = false;
+
 const MyTeam = () => {
   const router = useRouter();
   const team = useAppSelector((state) => state.team);
@@ -175,7 +178,7 @@ const MyTeam = () => {
                 />
               </View>
             </ScrollView>
-            {!isMatched && !team.hasUserChanges && (
+            {QUEUE_ENABLED && !isMatched && !team.hasUserChanges && (
               <FloatingActionButton
                 buttonBackground={cn(
                   "px-4",

--- a/client/hooks/useLineupLock.ts
+++ b/client/hooks/useLineupLock.ts
@@ -8,13 +8,10 @@ type UseLineupLockArgs = {
 };
 
 export const useLineupLock = ({ matchupStartDate }: UseLineupLockArgs) => {
-  const apiDate = useMemo(() => {
+  const apiDate = useMemo((): string | null => {
+    if (!matchupStartDate) return null;
+
     const now = new Date();
-
-    if (!matchupStartDate) {
-      return now.toISOString().split("T")[0];
-    }
-
     return now < new Date(matchupStartDate)
       ? matchupStartDate
       : now.toISOString().split("T")[0];
@@ -24,6 +21,8 @@ export const useLineupLock = ({ matchupStartDate }: UseLineupLockArgs) => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!apiDate) return;
+
     let cancelled = false;
 
     const getEarliestGame = async () => {
@@ -52,9 +51,12 @@ export const useLineupLock = ({ matchupStartDate }: UseLineupLockArgs) => {
   }, [apiDate]);
 
   const now = new Date();
-  const endOfGameDayPdt = getMidnightPdtFromDate(apiDate);
+  const endOfGameDayPdt = apiDate
+    ? getMidnightPdtFromDate(apiDate)
+    : new Date(0);
 
   const isLineupLocked =
+    !!apiDate &&
     !!earliestStartTime &&
     (now >= new Date(earliestStartTime) ||
       // When local time passes midnight in some timezones, `apiDate` advances to tomorrow

--- a/client/metro.config.js
+++ b/client/metro.config.js
@@ -3,9 +3,8 @@ const { withNativeWind } = require("nativewind/metro");
 
 const config = getDefaultConfig(__dirname);
 
-config.transformer.babelTransformerPath = require.resolve(
-  "react-native-svg-transformer",
-);
+config.transformer.babelTransformerPath =
+  require.resolve("react-native-svg-transformer");
 config.resolver.assetExts = config.resolver.assetExts.filter(
   (ext) => ext !== "svg",
 );


### PR DESCRIPTION
<!-- For titles, please adhere to the following title template if possible:
[Feature/Fix/Refactor]/[Identifier]: Short descriptive title
Ex. Bugfix/ENG-123: Fix app crash -->

## Related Issues

<!-- A link to any related issues or bugs that the pull request addresses, \
connecting the code's context with the issues it solves. Please see
https://linear.app/docs/github#link-to-a-linear-issue for keywords to link an issue.
Ex. Closes ENG-123, References ENG-456 -->

Closes ENG-122.

## Summary

<!-- Provide a concise summary as to why are the changes needed.
Include any relevant links, such as tickets, discussions, or design documents. -->

Two offseason-related issues were found when testing matchup queuing. Rather than ship known bugs, the queue button is temporarily disabled via a flag until fixes are ready. A related bug in `useLineupLock` that was hiding the player drop button whenever NBA games were running (even outside an active matchup) was also fixed.


## Changes Made

<!-- Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem and any notable
implementation details. -->

- `client/app/(protected)/(tabs)/index.tsx` — Added a `QUEUE_ENABLED` flag (currently `false`) at the top of the file. The queue/cancel-queue FAB is gated on this flag. To re-enable: set `QUEUE_ENABLED = true` once the offseason queue bugs are resolved.

- `client/hooks/useLineupLock.ts` — Fixed a bug where `useLineupLock` would fall back to today's date when no `matchupStartDate` was provided, causing it to fetch the live NBA schedule and lock the lineup during game hours even with no active matchup. `apiDate` now returns `null` when there's no matchup, skipping the fetch entirely and keeping `isLineupLocked` false.


<!-- Optional Sections -->

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can help reviewers understand
them more easily. -->

No additional screenshots

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull request, helping reviewers
validate the code. -->

1. Confirm the QUEUE button no longer appears on the My Team screen.
2. With no active matchup, confirm the drop (X) button is visible and functional on each filled player slot regardless of time of day.
3. With an active matchup and games running, confirm `isLineupLocked` still correctly locks the lineup.


## Special Notes for Your Reviewer(s)

<!-- If there are any specific instructions or considerations you want to highlight for the
reviewer, include them in this section. -->

`QUEUE_ENABLED` is intentionally left as a module-level constant in `index.tsx` rather than a separate config file — easy to find, easy to flip, no added abstraction.
