### PR TITLE
Bugfix/ENG-119: Fix logo grid left-alignment in team logo bottom sheet

### DIFF
--- a/client/app/(protected)/createTeam.tsx
+++ b/client/app/(protected)/createTeam.tsx
@@ -279,7 +279,7 @@ const CreateTeam = () => {
           control={control}
           name="logoUrl"
           render={({ field: { onChange } }) => (
-            <View className="mb-6 flex-1 flex-row flex-wrap justify-between px-6 py-4">
+            <View className="mb-6 flex-1 flex-row flex-wrap gap-x-[11%] px-6 py-4">
               {teamLogoOptions.map((teamLogoOption, index) => {
                 const isSelected =
                   selectedLogoOption.url === teamLogoOption.url;

--- a/client/components/AugmentStatusCard.tsx
+++ b/client/components/AugmentStatusCard.tsx
@@ -15,57 +15,57 @@ const AugmentStatusCard = () => {
   return (
     <Pressable onPress={() => setOpenDialog(true)}>
       {augment && (
-        <Dialog
-          closeLabel="Close"
-          dialogClassname="w-[75%]"
-          onClose={() => setOpenDialog(false)}
-          title="Selected augment"
-          visible={openDialog}
-        >
-          <View className="my-4 h-80 w-[75%] justify-center self-center">
-            <AugmentCard
-              cardData={augment}
-              onPress={() => setOpenDialog(false)}
-            />
+        <>
+          <Dialog
+            closeLabel="Close"
+            dialogClassname="w-[75%]"
+            onClose={() => setOpenDialog(false)}
+            title="Selected augment"
+            visible={openDialog}
+          >
+            <View className="my-4 h-80 w-[75%] justify-center self-center">
+              <AugmentCard
+                cardData={augment}
+                onPress={() => setOpenDialog(false)}
+              />
+            </View>
+          </Dialog>
+          <LinearGradient
+            colors={["#CCE8FE", "#CDA0FF", "#8489F5", "#CDF1FF", "#B591E9"]}
+            end={{ x: 1, y: 1 }}
+            start={{ x: 0, y: 0 }}
+            style={{
+              position: "absolute",
+              top: -3,
+              right: -3,
+              bottom: -3,
+              left: -3,
+              borderRadius: 16,
+              borderWidth: 1,
+            }}
+          />
+          <View className="w-full rounded-2xl bg-gray-900 p-4">
+            <View className="flex-row items-center justify-between gap-1">
+              <View className="flex-row items-center">
+                <Image className="h-8 w-8" source={iconMap[augment.iconUrl]} />
+                <Text className="pbk-h7 text-base-white">
+                  {augment.title.toUpperCase()}
+                </Text>
+              </View>
+              <View
+                className={cn(
+                  `h-5 w-16 items-center justify-center rounded-md`,
+                  augmentValid ? "bg-green-600" : "bg-gray-600",
+                )}
+              >
+                <Text className="pbk-b3 text-base-white">
+                  {augmentValid ? "Active" : "Inactive"}
+                </Text>
+              </View>
+            </View>
           </View>
-        </Dialog>
+        </>
       )}
-      <LinearGradient
-        colors={["#CCE8FE", "#CDA0FF", "#8489F5", "#CDF1FF", "#B591E9"]}
-        end={{ x: 1, y: 1 }}
-        start={{ x: 0, y: 0 }}
-        style={{
-          position: "absolute",
-          top: -3,
-          right: -3,
-          bottom: -3,
-          left: -3,
-          borderRadius: 16,
-          borderWidth: 1,
-        }}
-      />
-      <View className="w-full rounded-2xl bg-gray-900 p-4">
-        {augment && (
-          <View className="flex-row items-center justify-between gap-1">
-            <View className="flex-row items-center">
-              <Image className="h-8 w-8" source={iconMap[augment.iconUrl]} />
-              <Text className="pbk-h7 text-base-white">
-                {augment.title.toUpperCase()}
-              </Text>
-            </View>
-            <View
-              className={cn(
-                `h-5 w-16 items-center justify-center rounded-md`,
-                augmentValid ? "bg-green-600" : "bg-gray-600",
-              )}
-            >
-              <Text className="pbk-b3 text-base-white">
-                {augmentValid ? "Active" : "Inactive"}
-              </Text>
-            </View>
-          </View>
-        )}
-      </View>
     </Pressable>
   );
 };

--- a/client/metro.config.js
+++ b/client/metro.config.js
@@ -4,7 +4,7 @@ const { withNativeWind } = require("nativewind/metro");
 const config = getDefaultConfig(__dirname);
 
 config.transformer.babelTransformerPath = require.resolve(
-  "react-native-svg-transformer",
+  "react-native-svg-transformer"
 );
 config.resolver.assetExts = config.resolver.assetExts.filter(
   (ext) => ext !== "svg",

--- a/client/metro.config.js
+++ b/client/metro.config.js
@@ -3,9 +3,8 @@ const { withNativeWind } = require("nativewind/metro");
 
 const config = getDefaultConfig(__dirname);
 
-config.transformer.babelTransformerPath = require.resolve(
-  "react-native-svg-transformer"
-);
+config.transformer.babelTransformerPath =
+  require.resolve("react-native-svg-transformer");
 config.resolver.assetExts = config.resolver.assetExts.filter(
   (ext) => ext !== "svg",
 );

--- a/client/types/asset.ts
+++ b/client/types/asset.ts
@@ -55,10 +55,6 @@ export const teamLogoOptions: Asset[] = [
     source: require("../assets/images/placeholder-avatar.png"),
   },
   {
-    url: "../assets/images/team/1.png",
-    source: require("../assets/images/team/1.png"),
-  },
-  {
     url: "../assets/images/team/2.png",
     source: require("../assets/images/team/2.png"),
   },


### PR DESCRIPTION
## Related Issues

Closes ENG-119

## Summary

Three fixes in the team logo selection flow and augment status display:

1. The team logo grid in the Change Team Logo bottom sheet was using `justify-between`, causing icons on a partial last row to spread out with large gaps instead of staying left-aligned.
2. A duplicate entry in `teamLogoOptions` caused the same logo to appear twice in the grid.
3. `AugmentStatusCard` was rendering its card shell (gradient border + background) even when no augment was selected — the `augment &&` check now wraps the entire component output so nothing renders when there is no augment.

## Changes Made

- **`createTeam.tsx`**: Replaced `justify-between` with `gap-x-[11%]` on the logo grid container. With each item at `w-[26%]`, three items per row consume `3×26% + 2×11% = 100%`, preserving consistent spacing for full rows while keeping partial last rows left-aligned.
- **`types/asset.ts`**: Removed the duplicate `teamLogoOptions` entry that had the same `url` (`../assets/images/team/1.png`) as the entry above it.
- **`components/AugmentStatusCard.tsx`**: Moved the `augment &&` conditional to wrap the entire return — the `Dialog`, `LinearGradient`, and card `View` — so the card is fully hidden when the user has no augment equipped.

## Screenshots

No additional screenshots

## Testing Instructions

1. Open the Create Team or Edit Team screen and tap "Change team logo" — verify the grid shows no duplicate icons and the last row is left-aligned.
2. Navigate to a screen that renders `AugmentStatusCard` with no augment set — verify the card does not appear at all.
3. Equip an augment and verify the card renders correctly with the gradient border and active/inactive badge.

## Special Notes for Your Reviewer(s)

No additional notes